### PR TITLE
[Delivered #128543357] Got rid of boost signals2 dependency

### DIFF
--- a/Core/include/EventSubscriber.h
+++ b/Core/include/EventSubscriber.h
@@ -56,7 +56,7 @@ namespace Gsage {
       class HandlerDescriptor
       {
         public:
-          HandlerDescriptor(CallbackMemFn callback, EventDispatcher::EventConnection connection) : mCallback(callback), mConnection(connection) {};
+          HandlerDescriptor(CallbackMemFn callback, EventConnection connection) : mCallback(callback), mConnection(connection) {};
 
           void disconnect()
           {
@@ -74,7 +74,7 @@ namespace Gsage {
           }
         private:
           CallbackMemFn mCallback;
-          EventDispatcher::EventConnection mConnection;
+          EventConnection mConnection;
       };
 
       EventSubscriber() {};
@@ -116,7 +116,7 @@ namespace Gsage {
           addEventListener(dispatcher, DispatcherEvent::FORCE_UNSUBSCRIBE, &EventSubscriber<C>::onForceUnsubscribe);
         }
 
-        mConnections[subscription].push_back(HandlerDescriptor(callback, dispatcher->addEventListener(eventType, boost::bind(callback, (C*)this, _1, _2), priority)));
+        mConnections[subscription].push_back(HandlerDescriptor(callback, dispatcher->addEventListener(eventType, std::bind(callback, (C*)this, std::placeholders::_1, std::placeholders::_2), priority)));
       }
 
       /**

--- a/GsageFacade/CMakeLists.txt
+++ b/GsageFacade/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(WIN32)
 target_link_libraries(${LIB_NAME} ${LIBS})
 
 install(DIRECTORY include/ DESTINATION /usr/local/include/gsage
-  FILES_MATCHING PATTERN "*.h"
+  FILES_MATCHING PATTERN "*.(h|hpp)"
 )
 
 install(TARGETS ${LIB_NAME}

--- a/GsageFacade/src/lua/LuaInterface.cpp
+++ b/GsageFacade/src/lua/LuaInterface.cpp
@@ -25,8 +25,7 @@ THE SOFTWARE.
 */
 
 #include "lua/LuaInterface.h"
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
+
 #include <luabind/adopt_policy.hpp>
 #include <luabind/iterator_policy.hpp>
 #include <luabind/operator.hpp>

--- a/Tests/Core/TestEventDispatcher.cpp
+++ b/Tests/Core/TestEventDispatcher.cpp
@@ -64,6 +64,14 @@ class TestEventHandler : public EventSubscriber<TestEventHandler>
       return true;
     }
 
+    bool onTestEvent3(EventDispatcher* sender, const Event& event)
+    {
+      TestEvent e = (TestEvent&)event;
+      e.setHandled(mName);
+      receivedEvents.push_back(e);
+      return true;
+    }
+
     TestEvents& receivedEvents;
     std::string mName;
 
@@ -97,6 +105,12 @@ TEST_F(TestEventDispatcher, TestSimpleFlow)
 
   mInstance->fireEvent(TestEvent(TestEvent::PING, 100));
   ASSERT_EQ(receivedEvents.size(), 1);
+
+  handler.addEventListener(mInstance, TestEvent::PING, &TestEventHandler::onTestEvent);
+  handler.addEventListener(mInstance, TestEvent::PING, &TestEventHandler::onTestEvent2);
+  handler.addEventListener(mInstance, TestEvent::PING, &TestEventHandler::onTestEvent3);
+  mInstance->fireEvent(TestEvent(TestEvent::PING, 100));
+  ASSERT_EQ(receivedEvents.size(), 4);
 }
 
 /**

--- a/resources/gameConfig.json
+++ b/resources/gameConfig.json
@@ -10,7 +10,6 @@
 
   "plugins":
   [
-    "/usr/local/lib/libSFMLAudioPlugin",
     "PlugIns/Plugin_ParticleUniverseFactory"
   ],
 


### PR DESCRIPTION
Replaced it with small self made analog.

This PR is part of big task to remove Boost dependency completely from the project.
Migrate to gcc 4.9.
And use sol2 for lua bindings instead of luabind.

Need to make these changes, before I can continue adding more feature as they will use all this code, which I want to rewrite. It will be harder in future if I don't do it now.