### PR TITLE
Fixed engine crashes due to async waits in lua

### DIFF
--- a/GsageCore/include/systems/LuaScriptSystem.h
+++ b/GsageCore/include/systems/LuaScriptSystem.h
@@ -125,8 +125,11 @@ namespace Gsage
       /**
        * Add lua function which will be called on each update of the system
        * @param function Sol function object, only LUA_TFUNCTION will be added as listener
+       * @param global Flag to tell script system that the callback is a global function so it won't be
+       *               removed on LuaScriptSystem::unloadComponents call
+       * @returns true if passed type is a function
        */
-      bool addUpdateListener(const sol::object& function);
+      bool addUpdateListener(const sol::object& function, bool global = false);
 
       /**
        * Remove lua function from update listeners list
@@ -139,11 +142,22 @@ namespace Gsage
        */
       void unloadComponents();
     private:
+      struct Listener
+      {
+        Listener(sol::protected_function function, bool global)
+          : function(function)
+          , global(global)
+        {}
+
+        sol::protected_function function;
+        bool global;
+      };
+
       std::string getScriptData(const std::string& data);
 
       sol::state_view* mState;
 
-      typedef std::vector<sol::protected_function> UpdateListeners;
+      typedef std::vector<Listener> UpdateListeners;
       UpdateListeners mUpdateListeners;
 
       std::string mWorkdir;

--- a/resources/behaviors/trees/dumbMonster.lua
+++ b/resources/behaviors/trees/dumbMonster.lua
@@ -38,9 +38,9 @@ local function attack(self, context)
 
   self:render():lookAt(context.target:render().position, RenderComponent.Y_AXIS, OgreNode.TS_WORLD)
   self:render():playAnimation(anims[math.random(3)], 1, 1, 0, false)
-  async.waitSeconds(0.5)
+  context.waitSeconds(0.5)
   actions.inflictDamage(self, context.target)
-  async.waitSeconds(0.5)
+  context.waitSeconds(0.5)
   return true
 end
 

--- a/resources/behaviors/trees/healthChecker.lua
+++ b/resources/behaviors/trees/healthChecker.lua
@@ -4,7 +4,7 @@ local function isDead(self, context)
 end
 
 local function die(self, context)
-  async.waitSeconds(0.5)
+  context.waitSeconds(0.5)
   core:removeEntity(self.id)
   game:reset()
   game:loadSave("gameStart")
@@ -32,9 +32,9 @@ local function attack(self, context)
   self:render():lookAt(context.target:render().position, RenderComponent.Y_AXIS, OgreNode.TS_WORLD)
   local anims = {"attack1", "attack2"}
   self:render():playAnimation(anims[math.random(2)], 1, 1*aspd, 0, false)
-  async.waitSeconds(0.43/aspd)
+  context.waitSeconds(0.43/aspd)
   actions.inflictDamage(self, context.target)
-  async.waitSeconds(0.2/aspd)
+  context.waitSeconds(0.2/aspd)
   return true
 end
 

--- a/resources/scripts/entrypoints/chaos.lua
+++ b/resources/scripts/entrypoints/chaos.lua
@@ -143,7 +143,7 @@ function onReady(e)
     event:ogreSelect(core, "rollOut", onRoll)
   end
 
-  core:script():addUpdateListener(async.addTime)
+  core:script():addUpdateListener(async.addTime, true)
 
   spawn()
   spawnMore(10)

--- a/resources/scripts/lib/behaviors.lua
+++ b/resources/scripts/lib/behaviors.lua
@@ -1,4 +1,5 @@
 require 'lib.class'
+require 'lib.async'
 
 btree = btree or {}
 
@@ -57,6 +58,12 @@ BehaviorTree = class(function(self, context)
   self.currentBehavior = nil
   self.context = context
   self.mainCoroutine = nil
+  self.context.waitSeconds = function(time)
+    async.waitSeconds(time)
+    if not self.mainCoroutine then
+      error("btree stopped")
+    end
+  end
 end)
 
 function BehaviorTree:start(rootNode)


### PR DESCRIPTION
Now any btree leaf should use `context.waitSeconds(time)` instead of `async.waitSeconds(time)`.
Otherwise this fix won't work.