### PR TITLE
[#169033983][#169109031][#164074964] Fixed several serious issues

### DIFF
--- a/Core/src/lua/LuaInterface.cpp
+++ b/Core/src/lua/LuaInterface.cpp
@@ -425,6 +425,17 @@ namespace Gsage {
           }
           return res;
         },
+        "normals", [](Geom* geom){
+          float* normals;
+          int count;
+          std::tie(normals, count) = geom->getNormals();
+          std::vector<Gsage::Vector3> res;
+          res.reserve(count / 3);
+          for(int i = 0; i < count; i += 3) {
+            res.emplace_back(normals[i], normals[i + 1], normals[i + 2]);
+          }
+          return res;
+        },
         "tris", [](Geom* geom){
           int* tris;
           int count;

--- a/PlugIns/ImGUI/Common/src/ImGuiDockspace.cpp
+++ b/PlugIns/ImGUI/Common/src/ImGuiDockspace.cpp
@@ -96,7 +96,7 @@ namespace Gsage {
     float lineHeight = ImGui::GetTextLineHeight();
     ImGuiDockspaceStyle style;
     style.tabbarHeight = lineHeight * 1.2f;
-    style.splitterThickness = lineHeight / 6.5f;
+    style.splitterThickness = lineHeight / 5.0f;
     style.tabbarTextMargin = lineHeight / 1.7f;
     style.tabbarPadding = lineHeight / 26.0f;
     style.windowRounding = ImGui::GetStyle().WindowRounding;
@@ -1361,6 +1361,7 @@ namespace Gsage {
       ImGuiIO& io = ImGui::GetIO();
       float rounding = ImGui::GetStyle().WindowRounding;
       ImVec2 margin(rounding, rounding);
+      ImVec2 overlapMultiplier = ImVec2(0, 0);
 
       switch(dock->getLayout()) {
         case Dock::Horizontal:
@@ -1372,6 +1373,7 @@ namespace Gsage {
           pos.x += child->getSize().x;
           size = ImVec2(mStyle.splitterThickness, dock->getSize().y);
           cursor = ImGuiMouseCursor_ResizeEW;
+          overlapMultiplier.x = 1;
           break;
         case Dock::Vertical:
           if(dock->mResized) {
@@ -1382,6 +1384,7 @@ namespace Gsage {
           pos.y += child->getSize().y;
           size = ImVec2(dock->getSize().x, mStyle.splitterThickness);
           cursor = ImGuiMouseCursor_ResizeNS;
+          overlapMultiplier.y = 1;
           break;
         default:
           LOG(INFO) << "Can't draw splitters for layout " << dock->getLayout();
@@ -1393,10 +1396,13 @@ namespace Gsage {
       }
 
       ImVec2 screenPos = ImGui::GetCursorScreenPos();
-      ImGui::SetCursorScreenPos(pos);
       if(size.x > 0 && size.y > 0) {
-        ImGui::InvisibleButton("split", size);
+        ImVec2 buttonPos = pos - overlapMultiplier * size;
+        ImVec2 buttonSize = size + size * overlapMultiplier * 2;
+        ImGui::SetCursorScreenPos(buttonPos);
+        ImGui::InvisibleButton("split", buttonSize);
       }
+      ImGui::SetCursorScreenPos(pos);
 
       if (ImGui::IsItemHovered() && !ImGui::IsMouseDragging()) {
         dock->mResized = ImGui::IsMouseDown(0);
@@ -1412,8 +1418,10 @@ namespace Gsage {
         ImGui::SetMouseCursor(cursor);
       }
 
+      ImVec2 min = pos;
+      ImVec2 max = pos + size;
       canvas->AddRectFilled(
-          ImGui::GetItemRectMin() + margin, ImGui::GetItemRectMax() - margin, over ? mStyle.splitterHoveredColor : mStyle.splitterNormalColor);
+          min + margin, max - margin, over ? mStyle.splitterHoveredColor : mStyle.splitterNormalColor);
       ImGui::PopID();
       ImGui::SetCursorScreenPos(screenPos);
     }

--- a/PlugIns/ImGUI/Common/src/ImguiManager.cpp
+++ b/PlugIns/ImGUI/Common/src/ImguiManager.cpp
@@ -522,7 +522,7 @@ namespace Gsage {
     WindowPtr window = mFacade->getWindowManager()->getWindow(name);
     float scale = 1.0f;
     if(window) {
-      scale = std::max(1.0f, window->getScaleFactor() * .75f);
+      scale = std::max(1.0f, window->getScaleFactor() * .9f);
     }
 
     LOG(INFO) << "Creating ImGui context " << name;

--- a/PlugIns/ImGUI/OgreInterfaces/src/ImguiOgreRenderer.cpp
+++ b/PlugIns/ImGUI/OgreInterfaces/src/ImguiOgreRenderer.cpp
@@ -102,7 +102,8 @@ namespace Gsage {
           mFontTexHeight,
           1,
           1,
-          Ogre::PF_R8G8B8A8
+          Ogre::PF_R8G8B8A8,
+          Ogre::TU_DYNAMIC_WRITE_ONLY_DISCARDABLE
       );
 
       const Ogre::PixelBox& lockBox = mFontTex->getBuffer()->lock(Ogre::Image::Box(0, 0, mFontTexWidth, mFontTexHeight), OgreV1::HardwareBuffer::HBL_DISCARD);

--- a/PlugIns/OgrePlugin/include/ogre/MaterialBuilder.h
+++ b/PlugIns/OgrePlugin/include/ogre/MaterialBuilder.h
@@ -45,6 +45,13 @@ namespace Gsage {
        * @return true if succeed
        */
       static Ogre::MaterialPtr parse(const std::string& name, const DataProxy& data);
+
+#if OGRE_VERSION >= 0x020100
+      /**
+       * Create hlms material from json data
+       */
+      static Ogre::HlmsDatablock* parseHlms(const std::string& name, const DataProxy& data, bool rebuild = false);
+#endif
   };
 }
 

--- a/PlugIns/OgrePlugin/include/ogre/v2/ManualObjectWrapper.h
+++ b/PlugIns/OgrePlugin/include/ogre/v2/ManualObjectWrapper.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "ogre/MovableObjectWrapper.h"
 
 namespace Gsage {
+
   class ManualObjectWrapper : public MovableObjectWrapper<Ogre::ManualObject>
   {
     public:
@@ -38,6 +39,23 @@ namespace Gsage {
 
       ManualObjectWrapper();
       virtual ~ManualObjectWrapper();
+
+      /**
+       * Set manual object data
+       *
+       * @param data to create manual object from
+       */
+      void setData(const DataProxy& data);
+
+      /**
+       * Get manual object data
+       *
+       * @return data
+       */
+      const DataProxy& getData() const;
+
+    private:
+      DataProxy mData;
   };
 }
 

--- a/PlugIns/OgrePlugin/src/OgreGeom.cpp
+++ b/PlugIns/OgrePlugin/src/OgreGeom.cpp
@@ -1,28 +1,28 @@
 /*
-   -----------------------------------------------------------------------------
-   This file is a part of Gsage engine
+-----------------------------------------------------------------------------
+This file is a part of Gsage engine
 
-   Copyright (c) 2014-2018 Artem Chernyshev and contributors
+Copyright (c) 2014-2018 Artem Chernyshev and contributors
 
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
-   -----------------------------------------------------------------------------
-   */
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------
+*/
 
 #include "OgreGeom.h"
 #include <OgreNode.h>
@@ -45,9 +45,7 @@ namespace Gsage {
     size_t vertexCount = 0;
     size_t indexCount = 0;
     size_t indexOffset = 0;
-    size_t currentOffset = 0;
-    size_t sharedOffset = 0;
-    size_t nextOffset = 0;
+    size_t vertexOffset = 0;
 
     Ogre::MeshInformation* meshData = new Ogre::MeshInformation[mSrcEntities.size()];
     size_t meshCount = 0;
@@ -78,21 +76,20 @@ namespace Gsage {
 
     vertexCount *= 3;
 
-    size_t vertexOffset = 0;
-
     verts = new float[vertexCount];
     nverts = vertexCount;
     tris = new int[indexCount];
     ntris = indexCount;
     normals = new float[vertexCount];
+    int offset = 0;
 
-    for(int i = 0; i < meshCount; ++i) {
+    for(size_t i = 0; i < meshCount; ++i) {
       Ogre::MeshInformation& info = meshData[i];
-      for (size_t j = 0; j < info.indexCount; ++j) {
-        tris[indexOffset++] = (int)info.indices[j];
+      for(size_t j = 0; j < info.indexCount; ++j) {
+        tris[indexOffset++] = (int)info.indices[j] + offset;
       }
 
-      for( size_t j = 0; j < info.vertexCount; ++j)
+      for(size_t j = 0; j < info.vertexCount; ++j)
       {
         verts[vertexOffset] = info.vertices[j].x;
         verts[vertexOffset+1] = info.vertices[j].y;
@@ -103,6 +100,8 @@ namespace Gsage {
         normals[vertexOffset+2] = info.normals[j].z;
         vertexOffset += 3;
       }
+
+      offset += info.vertexCount;
     }
 
     delete[] meshData;

--- a/PlugIns/OgrePlugin/src/ogre/v2/ManualObjectWrapper.cpp
+++ b/PlugIns/OgrePlugin/src/ogre/v2/ManualObjectWrapper.cpp
@@ -24,7 +24,16 @@ THE SOFTWARE.
 -----------------------------------------------------------------------------
 */
 
+#include <OgreMovableObject.h>
+#include <OgreRenderable.h>
+
+#include <Vao/OgreVaoManager.h>
+#include <Vao/OgreVertexArrayObject.h>
+
+#include <OgreSceneManager.h>
+
 #include "ogre/v2/ManualObjectWrapper.h"
+#include "ogre/MaterialBuilder.h"
 
 namespace Gsage {
 
@@ -32,10 +41,137 @@ namespace Gsage {
 
   ManualObjectWrapper::ManualObjectWrapper()
   {
+    BIND_ACCESSOR("data", &ManualObjectWrapper::setData, &ManualObjectWrapper::getData);
   }
 
   ManualObjectWrapper::~ManualObjectWrapper()
   {
+  }
+
+  const DataProxy& ManualObjectWrapper::getData() const
+  {
+    return mData;
+  }
+
+  void ManualObjectWrapper::setData(const DataProxy& data)
+  {
+    auto ppoints = data.get<DataProxy>("points");
+    if(!ppoints.second) {
+      LOG(ERROR) << "Manual object \"" << mObjectId << "\" has no points defined";
+      return;
+    }
+
+    mData = data;
+
+    Ogre::OperationType op = data.get("renderOperation", Ogre::OT_LINE_STRIP);
+    if(op != Ogre::OT_TRIANGLE_LIST && op != Ogre::OT_LINE_LIST && op != Ogre::OT_LINE_STRIP) {
+      return;
+    }
+
+    if(mObject) {
+      mObject->detachFromParent();
+      mSceneManager->destroyManualObject(mObject);
+    }
+
+    Ogre::ManualObject* manualObject = mSceneManager->createManualObject(Ogre::SCENE_DYNAMIC);
+    mObject = manualObject;
+
+    auto mat = data.get<DataProxy>("material");
+
+    std::string materialName = mObjectId + "Material";
+    if(mat.second) {
+      MaterialBuilder::parseHlms(materialName, mat.first);
+    } else {
+      LOG(WARNING) << "No material defined for manual object \"" << mObjectId << "\"";
+    }
+
+    manualObject->begin(materialName, op);
+    size_t pc = 0;
+
+    auto indices = data.get<DataProxy>("indices");
+    bool manualIndices = indices.second;
+    if(manualIndices) {
+      for(auto i : indices.first) {
+        auto e = i.second.getValue<int>();
+        if(!e.second) {
+          LOG(ERROR) << "Got malformed index " << i.second.getValueOptional<std::string>("");
+          return;
+        }
+        manualObject->index(e.first);
+      }
+    }
+
+    auto manualNormals = data.get<DataProxy>("normals");
+    std::vector<Gsage::Vector3> normals;
+    if(manualNormals.second) {
+      size_t index = 0;
+      for(auto p : manualNormals.first) {
+        Gsage::Vector3 normal(0, 0, 1);
+        if(!p.second.getValue(normal)) {
+          LOG(WARNING) << "Malformed normal definition " << p.second.getValueOptional<std::string>("");
+        }
+        normals.push_back(normal);
+      }
+    }
+
+    std::vector<Gsage::Vector3> points;
+    points.reserve(ppoints.first.size());
+    for(auto p : ppoints.first) {
+      Gsage::Vector3 point(0, 0, 0);
+      if(!p.second.getValue(point)) {
+        LOG(WARNING) << "Malformed point definition " << p.second.getValueOptional<std::string>("");
+      }
+      points.push_back(point);
+    }
+
+    Gsage::Vector3 generatedNormal;
+    size_t ni = 0;
+    // Points list was updated, redraw manual object
+    for(size_t i = 0; i < points.size(); ++i) {
+      Gsage::Vector3 point = points[i];
+      manualObject->position(point.X, point.Y, point.Z);
+      if(ni < normals.size()) {
+        Gsage::Vector3 normal = normals[ni++];
+        manualObject->normal(normal.X, normal.Y, normal.Z);
+      } else if(op == Ogre::OT_TRIANGLE_LIST) {
+        if(i == 0 && points.size() > 2) {
+          generatedNormal = Gsage::Vector3::Cross(points[i + 1] - points[i], points[i + 2] - points[i]);
+        }
+        manualObject->normal(generatedNormal.X, generatedNormal.Y, generatedNormal.Z);
+
+        if(manualObject->currentVertexCount() % 3 == 0 && i + 3 < points.size()) {
+          generatedNormal = Gsage::Vector3::Cross(points[i + 2] - points[i + 1], points[i + 3] - points[i + 1]);
+        }
+      } else {
+        manualObject->normal(0, 0, 1);
+      }
+
+      if(!manualIndices) {
+        switch(op) {
+          case Ogre::OT_TRIANGLE_LIST:
+          case Ogre::OT_TRIANGLE_STRIP:
+            if(manualObject->currentVertexCount() % 3 == 0) {
+              manualObject->triangle(pc, pc + 1, pc + 2);
+              pc = manualObject->currentVertexCount();
+            }
+            break;
+          case Ogre::OT_LINE_LIST:
+            if(manualObject->currentVertexCount() % 2 == 0) {
+              manualObject->line(pc, pc + 1);
+              pc = manualObject->currentVertexCount();
+            }
+            break;
+          default:
+            manualObject->index(i);
+        }
+      }
+    }
+    manualObject->end();
+    attachObject(manualObject);
+    mObject = manualObject;
+    defineUserBindings();
+    // disable query
+    mObject->setQueryFlags(0);
   }
 
 }

--- a/PlugIns/RecastNavigation/src/RecastWrapper.cpp
+++ b/PlugIns/RecastNavigation/src/RecastWrapper.cpp
@@ -110,6 +110,9 @@ namespace Gsage {
     float cellSize;
     int tileSize, maxTiles, maxPolys;
 
+    tileSize = 300;
+    cellSize = 0.3;
+
     config.read("cellSize", cellSize);
     config.read("tileSize", tileSize);
 

--- a/resources/locales/en_US.json
+++ b/resources/locales/en_US.json
@@ -361,6 +361,7 @@
       "merge": "Merge Into Existing Mavmesh"
     },
     "visualize": {
+      "show_rawgeom": "Show Raw Geometry (source)",
       "show_navmesh": "Show Navigation Mesh",
       "show_path": "Show Navigation Path"
     }

--- a/resources/scripts/editor/plugins.lua
+++ b/resources/scripts/editor/plugins.lua
@@ -79,6 +79,7 @@ local function decorate(cls)
     local renderData = self.render.props
     renderData.root.children[1].children[1].children = {{
       type = "model",
+      query = "dynamic",
       mesh = meshName,
       name = meshID,
       renderQueue = RENDER_QUEUE_ASSET_VIEWER,

--- a/resources/scripts/helpers/recast.lua
+++ b/resources/scripts/helpers/recast.lua
@@ -13,9 +13,9 @@ function recast.visualizePath(points, drawPoints, name)
           passes = {{
             depthCheckEnabled = false,
             colors = {
-              diffuse = "0xFFCC00",
-              ambient = "0xffcc00",
-              illumination = "0xFFCC00",
+              diffuse = "0xFFFFCC00",
+              ambient = "0xFFffcc00",
+              illumination = "0xFFFFCC00",
             },
             vertexProgram = "stdquad_vp",
             fragmentProgram = "stdquad_fp",
@@ -63,6 +63,67 @@ function recast.visualizePath(points, drawPoints, name)
   })
 end
 
+function recast.visualizeGeom()
+  local bounds = BoundingBox.new(BoundingBox.EXTENT_INFINITE)
+  local geom = core:render():getGeometry(bounds, RenderComponent.STATIC)
+
+  local verts = geom:verts()
+  local tris = geom:tris()
+  local norms = geom:normals()
+
+  local points = {}
+  for i = 1,#verts do
+    points[i] = verts[i]
+  end
+
+  local indices = {}
+  for i = 1,#tris do
+    indices[i] = tris[i]
+  end
+
+  local normals = {}
+  for i = 1,#norms do
+    normals[i] = norms[i]
+  end
+
+  return data:createEntity({
+    id = "geom",
+    render = {
+      root = {
+        position = Vector3.new(0, 0, 0),
+        rotation = Quaternion.new(1, 0, 0, 0),
+        children = {
+          {
+            type = "manualObject",
+            name = "rawgeom",
+            data = {
+              material = {
+                techniques = {{
+                  passes = {{
+                    colors = {
+                      diffuse = "0xFF335555",
+                      ambient = "0xFF335555",
+                      illumination = "0xFF114499",
+                    },
+                    vertexProgram = "stdquad_vp",
+                    fragmentProgram = "stdquad_fp",
+                  },}
+                },}
+              },
+              renderOperation = ogre.OT_TRIANGLE_LIST,
+              points = points,
+              indices = indices,
+              normals = normals,
+            }
+          }
+        }
+      },
+      vertexProgram = "stdquad_vp",
+      fragmentProgram = "stdquad_fp",
+    }
+  })
+end
+
 function recast.visualizeNavmesh()
   if core.navigation then
     local points = core:navigation():getNavMeshRawPoints()
@@ -75,9 +136,9 @@ function recast.visualizeNavmesh()
           techniques = {{
             passes = {{
               colors = {
-                diffuse = "0x335555",
-                ambient = "0x335555",
-                illumination = "0x114499",
+                diffuse = "0xFF335555",
+                ambient = "0xFF335555",
+                illumination = "0xFF114499",
               },
               vertexProgram = "stdquad_vp",
               fragmentProgram = "stdquad_fp",
@@ -95,9 +156,9 @@ function recast.visualizeNavmesh()
           techniques = {{
             passes = {{
               colors = {
-                diffuse = "0x335555",
-                ambient = "0x335555",
-                illumination = "0x1199FF",
+                diffuse = "0xFF335555",
+                ambient = "0xFF335555",
+                illumination = "0xFF1199FF",
               },
               vertexProgram = "stdquad_vp",
               fragmentProgram = "stdquad_fp",
@@ -129,9 +190,9 @@ function recast.visualizeNavmesh()
             techniques = {{
               passes = {{
                 colors = {
-                  diffuse = "0x114444",
-                  ambient = "0x114444",
-                  illumination = "0x113355",
+                  diffuse = "0xFF114444",
+                  ambient = "0xFF114444",
+                  illumination = "0xFF113355",
                 },
                 vertexProgram = "stdquad_vp",
                 fragmentProgram = "stdquad_fp",

--- a/resources/scripts/imgui/components/webview.lua
+++ b/resources/scripts/imgui/components/webview.lua
@@ -182,7 +182,7 @@ function WebView:render(width, height)
         scalingFactor = 1.5
 
       },
-      usage = ogre.HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE
+      usage = ogre.TU_DYNAMIC_WRITE_ONLY_DISCARDABLE
     })
 
     self.image:setTexture(self.textureID)

--- a/resources/scripts/imgui/systems/recast.lua
+++ b/resources/scripts/imgui/systems/recast.lua
@@ -67,6 +67,14 @@ local RecastEditorView = class(ImguiWindow, function(self, open, dockable)
           self.navmeshDraw = nil
         end
       end},
+      showRawGeom = {"recast.visualize.show_rawgeom", function(enabled)
+        if enabled then
+          self.geomDraw = recast.visualizeGeom()
+        elseif self.geomDraw then
+          core:removeEntity(self.geomDraw.id)
+          self.geomDraw = nil
+        end
+      end},
       showPath = {"recast.visualize.show_path", function(enabled)
         self:setShowNavPathEnabled(enabled)
       end},
@@ -160,6 +168,13 @@ function RecastEditorView:__call()
           self.navmeshDraw = nil
         end
         self.navmeshDraw = recast.visualizeNavmesh()
+      end
+      if self.buildOptions.showRawGeom then
+        if self.geomDraw then
+          core:removeEntity(self.geomDraw.id)
+          self.geomDraw = nil
+        end
+        self.geomDraw = recast.visualizeGeom()
       end
     end
     self:imguiEnd()


### PR DESCRIPTION
- Raw geometry was broken when queried against several objects. Recast
wasn't functional due to that.
- Recast rebuild was taking asset viewer entity into account, which is
now located highly above zero point, thus Recast geometry boundary was
enormous. Rebuild was triggerring generation for a huge area.

Ogre 2.1 plugin now utilises `Ogre::ManualObject`, support for that was added
to debug issues with recast.